### PR TITLE
Fix: fixed runtime issue on Windows

### DIFF
--- a/src/main/transaction/CardSecuritySetting.h
+++ b/src/main/transaction/CardSecuritySetting.h
@@ -36,7 +36,7 @@ using namespace calypsonet::terminal::reader;
  *
  * @since 1.0.0
  */
-class CardSecuritySetting : virtual public CommonSecuritySetting<CardSecuritySetting> {
+class CardSecuritySetting : virtual public CommonSecuritySetting {
 public:
     /**
      * Defines the SAM and the reader through which it is accessible to be used to handle the
@@ -190,6 +190,7 @@ public:
      */
     virtual CardSecuritySetting& setPinModificationCipheringKey(const uint8_t kif,
                                                                 const uint8_t kvc) = 0;
+
 };
 
 }

--- a/src/main/transaction/CommonSecuritySetting.h
+++ b/src/main/transaction/CommonSecuritySetting.h
@@ -36,9 +36,13 @@ using namespace calypsonet::terminal::reader;
  * @param <S> The type of the lowest level child object.
  * @since 1.2.0
  */
-template <typename S>
 class CommonSecuritySetting {
 public:
+    /**
+     * 
+     */
+    virtual ~CommonSecuritySetting() = default;
+    
     /**
      * Defines the control SAM and the reader through which it is accessible to be used to handle
      * the relevant cryptographic operations.
@@ -50,8 +54,9 @@ public:
      *        CalypsoSam is equal to CalypsoSam::ProductType::UNKNOWN.
      * @since 1.2.0
      */
-    virtual S& setControlSamResource(const std::shared_ptr<CardReader> samReader,
-                                     const std::shared_ptr<CalypsoSam> calypsoSam) = 0;
+    virtual CommonSecuritySetting& setControlSamResource(
+        const std::shared_ptr<CardReader> samReader,
+        const std::shared_ptr<CalypsoSam> calypsoSam) = 0;
 
     /**
      * Sets the service to be used to dynamically check if a SAM is revoked or not.
@@ -61,7 +66,8 @@ public:
      * @throws IllegalArgumentException If the provided service is null.
      * @since 1.2.0
      */
-    virtual S& setSamRevocationService(const std::shared_ptr<SamRevocationServiceSpi> service) = 0;
+    virtual CommonSecuritySetting& setSamRevocationService(
+        const std::shared_ptr<SamRevocationServiceSpi> service) = 0;
 };
 
 }

--- a/src/main/transaction/CommonTransactionManager.h
+++ b/src/main/transaction/CommonTransactionManager.h
@@ -51,7 +51,7 @@ public:
      * @return Null if the transaction does not use security settings.
      * @since 1.2.0
      */
-    virtual const std::shared_ptr<S> getSecuritySetting() const = 0;
+    virtual const std::shared_ptr<CommonSecuritySetting> getSecuritySetting() const = 0;
 
     /**
      * Returns the audit data of the transaction containing all APDU exchanges with the card and the

--- a/src/main/transaction/SamSecuritySetting.h
+++ b/src/main/transaction/SamSecuritySetting.h
@@ -22,7 +22,7 @@ namespace transaction {
  *
  * @since 1.2.0
  */
-class SamSecuritySetting : virtual public CommonSecuritySetting<SamSecuritySetting> {
+class SamSecuritySetting : virtual public CommonSecuritySetting {
 public:
     /**
      *


### PR DESCRIPTION
- Tried to remove the need for the use of std::reinterpret_pointer_cast by always using the most basic for of CommonSecuritySetting